### PR TITLE
Add cron scripts for synchronizing mirror repos.

### DIFF
--- a/.openshift/cron/hourly/list_mirrors.py
+++ b/.openshift/cron/hourly/list_mirrors.py
@@ -1,0 +1,7 @@
+import json
+import sys
+
+for repo in json.load(sys.stdin):
+    clone_uri = repo.get('clone_uri')
+    if clone_uri is not None:
+        print repo['repo_id']

--- a/.openshift/cron/hourly/synch_mirrors.sh
+++ b/.openshift/cron/hourly/synch_mirrors.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Synchronize mirrored repositories.
+#
+ROOT="$OPENSHIFT_DATA_DIR"
+VENV="$ROOT/kallithea-venv"
+BIN="$VENV/bin"
+API_HOST="http://$OPENSHIFT_DIY_HOST:$OPENSHIFT_DIY_PORT/"
+API_KEY="DEADBEEFDEADBEEF"
+K_API="$BIN/kallithea-api --apikey=$API_KEY --apihost=$API_HOST"
+
+for rid in $($K_API get_repos --format=json | $BIN/python list_mirrors.py); do
+    $K_API pull repoid:$rid
+done


### PR DESCRIPTION
Note that the `sync_mirrors.sh` script needs to have a "real" API key.  If the `build` hook could somehow generate the `_config` file with the key in it, that requirement would drop out.
